### PR TITLE
Support Ubuntu 22.04 host

### DIFF
--- a/.github/workflows/test_fn_install.yml
+++ b/.github/workflows/test_fn_install.yml
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023 David Schall and EASE Lab
+# Copyright (c) 2022 David Schall and EASE Lab
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,8 +47,53 @@ jobs:
         host-os: [ ubuntu-20.04, ubuntu-22.04 ]
     env:
       WORKING_DIR: wkdir/
+      RESOURCES: resources/
       VERSION: latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+
+      ### Setup working environment ####
+      - name: Set up Python version
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip' # caching pip dependencies
+
+      - name: Set up python dependencies
+        run: pip install -r ./setup/requirements.txt
+
+      - name: Set Qemu dependencies
+        run: |
+          make -f ./setup/disk.Makefile dep_install
+
+      - name: Download Artifacts
+        shell: bash
+        run: |
+          python ./resources/artifacts.py \
+                    --version $VERSION
+
+
+
+
+      ## Test the function installation as described
+      ## in the quick start guide
+
+      - name: Build the working directory
+        shell: bash
+        run: |
+          make -f ./simulation/Makefile build-wkdir
+
+      - name: Pull, and test the function containers
+        shell: bash
+        timeout-minutes: 15
+        env:
+          CPU: max
+        run: |
+          make -f ./simulation/Makefile install_functions
+
+      - name: Verify a successful installation
+        shell: bash
+        run: |
+          make -f ./simulation/Makefile install_check

--- a/simulation/Makefile
+++ b/simulation/Makefile
@@ -35,10 +35,12 @@ GEM5_DIR	?= $(RESOURCES)/gem5/
 ## Machine parameter
 MEMORY 	:= 2G
 CPUS    := 2
+CPU 	?= host -enable-kvm
 
 
 ## Required resources
 KERNEL 		?= $(RESOURCES)/kernel
+CLIENT 		?= $(RESOURCES)/client
 DISK		?= $(RESOURCES)/disk-image.qcow2
 GEM5		?= $(RESOURCES)/gem5/build/X86/gem5.opt
 
@@ -70,15 +72,13 @@ $(WORKING_DIR):
 $(WK_KERNEL): $(KERNEL)
 	cp $< $@
 
+$(WK_CLIENT): $(CLIENT)
+	cp $< $@
+
+
 # Create the disk image from the base image
 $(WK_DISK): $(DISK)
 	qemu-img convert $< $@
-
-
-## Build test client from sources
-$(WK_CLIENT):
-	cd $(ROOT)/tools/client/ &&	$(MAKE) all
-	cp $(ROOT)/tools/client/client $@
 
 
 #
@@ -135,7 +135,7 @@ $(WORKING_DIR)/%.sh: $(TEMPLATES_DIR)/%.tmpl.sh
 run_emulator:
 	sudo qemu-system-x86_64 \
 		-nographic \
-		-cpu host -enable-kvm \
+		-cpu ${CPU} \
 		-smp ${CPUS} \
 		-m ${MEMORY} \
 		-drive file=$(WK_DISK),format=raw,if=virtio \


### PR DESCRIPTION
Currently the client is build on the host machine. This can create issues in case the host and disk-image are different.
Download client instead building.
closes #81 